### PR TITLE
chore: add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module landaire/png-crc-fix
+
+go 1.20


### PR DESCRIPTION
fixes:
```
❯ go build
go: cannot find main module, but found .git/config in /Users/oliver.mannion/code3/png-crc-fix
	to create a module there, run:
	go mod init
```	